### PR TITLE
[Fix #5897] Apply symbol and word array conversion to array of size 1

### DIFF
--- a/lib/rubocop/cop/mixin/array_syntax.rb
+++ b/lib/rubocop/cop/mixin/array_syntax.rb
@@ -8,7 +8,7 @@ module RuboCop
       private
 
       def bracketed_array_of?(element_type, node)
-        return false unless node.square_brackets? && node.values.size > 1
+        return false unless node.square_brackets? && node.values.size >= 1
 
         node.values.all? { |value| value.type == element_type }
       end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -65,10 +65,6 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       expect_no_offenses('%i(one two three)')
     end
 
-    it 'does not register an offense for array with one element' do
-      expect_no_offenses('[:three]')
-    end
-
     it 'does not register an offense if symbol contains whitespace' do
       expect_no_offenses('[:one, :two, :"space here"]')
     end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       expect(new_source).to eq('%i(one two three)')
     end
 
+    it 'autocorrects array of one symbol' do
+      new_source = autocorrect_source('[:one]')
+      expect(new_source).to eq('%i(one)')
+    end
+
     it 'autocorrects arrays of symbols with new line' do
       new_source = autocorrect_source("[:one,\n:two, :three,\n:four]")
       expect(new_source).to eq("%i(one\ntwo three\nfour)")

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -139,6 +139,11 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       expect(new_source).to eq('%W(one two \n \t)')
     end
 
+    it 'auto-corrects an array of one word' do
+      new_source = autocorrect_source('[%Q(one)]')
+      expect(new_source).to eq('%W(one)')
+    end
+
     it 'keeps the line breaks in place after auto-correct' do
       new_source = autocorrect_source(["['one',",
                                        "'two', 'three']"])

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -82,10 +82,6 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       expect_no_offenses('%w(one two three)')
     end
 
-    it 'does not register an offense for array with one element' do
-      expect_no_offenses('["three"]')
-    end
-
     it 'does not register an offense for array with empty strings' do
       expect_no_offenses('["", "two", "three"]')
     end
@@ -141,7 +137,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
 
     it 'auto-corrects an array of one word' do
       new_source = autocorrect_source('[%Q(one)]')
-      expect(new_source).to eq('%W(one)')
+      expect(new_source).to eq('%w(one)')
     end
 
     it 'keeps the line breaks in place after auto-correct' do


### PR DESCRIPTION
Ensures `Style/SymbolArray` and `Style/WordArray` work on arrays of size 1 when `MinSize` allows it.

Fixes #5897